### PR TITLE
Feat: Update default location and currency to PHP

### DIFF
--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -5,11 +5,11 @@ export const APP_NAME = "Coffee Shop";
 export const GOOGLE_OAUTH_CLIENT_ID = import.meta.env.VITE_GOOGLE_OAUTH_CLIENT_ID;
 
 export const defaultCoordinate: LatLng = {
-  lng: 96.17045650343823,
-  lat: 16.785692464382592,
+  lng: 121.0501,
+  lat: 14.5405,
 };
 
-export const defaultDeliFee = 2000;
+export const defaultDeliFee = 100;
 
 export const coffeeSizeOptions = [
   {
@@ -42,15 +42,5 @@ export const paymentMethodOptions = [
     value: PaymentMethod.CASH,
     label: "Cash on Delivery",
     icon: '/images/cash-payment-icon.png',
-  },
-  {
-    value: PaymentMethod.KBZ_PAY,
-    label: "KBZ Pay",
-    icon: '/images/kbz-pay-icon.png',
-  },
-  {
-    value: PaymentMethod.WAVE_MONEY,
-    label: "Wave Money",
-    icon: '/images/wave-money-icon.png',
   },
 ];

--- a/frontend/src/utils/helper.ts
+++ b/frontend/src/utils/helper.ts
@@ -5,7 +5,7 @@ export function classNames(...classes: (string | undefined)[]) {
 function formatPrice(price: number): string {
   return price.toLocaleString('en-US', {
     style: 'currency',
-    currency: 'MMK',
+    currency: 'PHP',
     // minimumFractionDigits: 2,
   });
 }


### PR DESCRIPTION
Updates the application to use BGC, Taguig, Metro Manila as the default location and PHP as the currency.

- Changes the default coordinates in `frontend/src/constants/constants.ts`.
- Updates the currency formatting in `frontend/src/utils/helper.ts` to use PHP.
- Adjusts the default delivery fee to a value more appropriate for PHP.
- Removes Myanmar-specific payment methods.