### PR TITLE
feat: Add 'Use my current location' feature

### DIFF
--- a/frontend/src/hooks/provider/ModalProvider/AddressModal/ControlButtons.tsx
+++ b/frontend/src/hooks/provider/ModalProvider/AddressModal/ControlButtons.tsx
@@ -1,24 +1,37 @@
 import ButtonFilled from '@/components/shared/button/ButtonFilled';
 import ButtonOutline from '@/components/shared/button/ButtonOutline';
+import { LocationMarkerIcon } from '@heroicons/react/outline';
 
 interface ControlButtonsProps {
   onCancelClick: () => void;
   onConfirmClick: () => void;
+  onCurrentLocationClick: () => void;
   confirmBtnDisabled: boolean;
 }
 
 export default function ControlButtons({
   onCancelClick,
   onConfirmClick,
+  onCurrentLocationClick,
   confirmBtnDisabled,
 }: ControlButtonsProps) {
-
   return (
-    <div className="flex justify-between mt-4">
-      <ButtonOutline onClick={onCancelClick}>Cancel</ButtonOutline>
-      <ButtonFilled onClick={onConfirmClick} disabled={confirmBtnDisabled}>
-        Confirm
-      </ButtonFilled>
-    </div>
+    <>
+      <div className="mt-4">
+        <button
+          className="w-full text-primary-400 font-semibold text-lg flex items-center justify-center"
+          onClick={onCurrentLocationClick}
+        >
+          <LocationMarkerIcon className="w-6 h-6" />
+          <p className="ml-2">Use my current location</p>
+        </button>
+      </div>
+      <div className="flex justify-between mt-4">
+        <ButtonOutline onClick={onCancelClick}>Cancel</ButtonOutline>
+        <ButtonFilled onClick={onConfirmClick} disabled={confirmBtnDisabled}>
+          Confirm
+        </ButtonFilled>
+      </div>
+    </>
   );
 }

--- a/frontend/src/hooks/provider/ModalProvider/AddressModal/index.tsx
+++ b/frontend/src/hooks/provider/ModalProvider/AddressModal/index.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { LatLng, UserAddress } from '@/types';
 import useDebounce from '@/hooks/useDebounce';
 import { useUserAddress } from '@/hooks/useUserAddress';
-import MapComponent from '@/components/shared/MapComponent';
+import MapComponent, {
+  MapComponentRef,
+} from '@/components/shared/MapComponent';
 import BaseModal from '@/components/shared/modal/BaseModal';
 import StickyModalHeader from '../StickyModalHeader';
 import FlexContainer from '../FlexContainer';
@@ -45,6 +47,19 @@ export default function AddressModal({ show, onClose }: AddressModalProps) {
     }
   };
 
+  const mapRef = useRef<MapComponentRef>(null);
+
+  const handleCurrentLocation = () => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition((position) => {
+        const { latitude, longitude } = position.coords;
+        const newCoord = { lat: latitude, lng: longitude };
+        mapRef.current?.setNewPosition(newCoord);
+        handleCoordChange(newCoord);
+      });
+    }
+  };
+
   return (
     <BaseModal show={show} onClose={() => {}} fullScreen>
       <FlexContainer>
@@ -56,11 +71,15 @@ export default function AddressModal({ show, onClose }: AddressModalProps) {
             isLoading={isLoading}
           />
           <div className="w-full h-80 sm:h-72 bg-gray-300 rounded-lg overflow-hidden mt-4">
-            <MapComponent onCoordChange={handleCoordChange} />
+            <MapComponent
+              ref={mapRef}
+              onCoordChange={handleCoordChange}
+            />
           </div>
           <ControlButtons
             onCancelClick={onClose}
             onConfirmClick={handelConfirm}
+            onCurrentLocationClick={handleCurrentLocation}
             confirmBtnDisabled={confirmBtnDisabled}
           />
         </FullHeightContainer>


### PR DESCRIPTION
This commit introduces a new feature that allows users to use their current geographical location as their address.

A "Use my current location" button has been added to the address modal. When clicked, the application retrieves the user's current latitude and longitude using the browser's Geolocation API.

The map is then centered on this new location, and the corresponding address is fetched and displayed.

This feature improves user experience by simplifying the process of setting a delivery or pickup address.