### PR TITLE
Fix: 'useEffect is not defined' error in MapComponent

### DIFF
--- a/frontend/src/components/shared/MapComponent.tsx
+++ b/frontend/src/components/shared/MapComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { LatLng } from '@/types';
 import { useUserAddress } from '@/hooks/useUserAddress';
 import { MapContainer, TileLayer, Marker } from 'react-leaflet';


### PR DESCRIPTION
The `useEffect` hook was used in `MapComponent.tsx` without being imported from React. This change adds the import, fixing the `ReferenceError` that was crashing the component.