### PR TITLE
feat: Add getOrderList function to order service

### DIFF
--- a/frontend/src/pages/OrderHistoryPage/useOrders.tsx
+++ b/frontend/src/pages/OrderHistoryPage/useOrders.tsx
@@ -11,7 +11,7 @@ export default function useOrders() {
     const getData = async () => {
       setLoding(true);
       await fakeTimer(1000);
-      const res = getOrderList();
+      const res = await getOrderList();
       setData(res);
       setLoding(false);
     };

--- a/frontend/src/service/order.ts
+++ b/frontend/src/service/order.ts
@@ -16,3 +16,13 @@ export async function addOrder(
     return null;
   }
 }
+
+export async function getOrderList(): Promise<DeliveryOrder[]> {
+  try {
+    const response = await axios.get(API_URL);
+    return response.data;
+  } catch (err) {
+    console.log('Error:: getOrderList :', err);
+    return [];
+  }
+}


### PR DESCRIPTION
The 'getOrderList' function was missing from the order service, which caused a 'SyntaxError' in the 'useOrders' hook. This change adds the 'getOrderList' function to 'frontend/src/service/order.ts' and updates the 'useOrders' hook to correctly 'await' the function call.