### PR TITLE
Fix: Correctly import and use getOrderById

### DIFF
--- a/frontend/src/pages/OrderDetailPage/useOrders.tsx
+++ b/frontend/src/pages/OrderDetailPage/useOrders.tsx
@@ -11,8 +11,8 @@ export default function useOrder(id: string | undefined) {
     const getData = async () => {
       setLoding(true);
       await fakeTimer(1000);
-      const res = getOrderById(id!);
-      if(res){
+      const res = await getOrderById(id!);
+      if (res) {
         setData(res);
       }
       setLoding(false);

--- a/frontend/src/service/order.ts
+++ b/frontend/src/service/order.ts
@@ -26,3 +26,15 @@ export async function getOrderList(): Promise<DeliveryOrder[]> {
     return [];
   }
 }
+
+export async function getOrderById(
+  orderId: string
+): Promise<DeliveryOrder | null> {
+  try {
+    const response = await axios.get(`${API_URL}/${orderId}`);
+    return response.data;
+  } catch (err) {
+    console.log('Error:: getOrderById :', err);
+    return null;
+  }
+}


### PR DESCRIPTION
The `useOrders.tsx` hook was trying to import `getOrderById` from `service/order.ts`, but the function did not exist in that file. This caused an `Uncaught SyntaxError`.

This commit adds the `getOrderById` function to `service/order.ts` to fetch a single order from the API. It also adds the necessary `await` keyword in `useOrders.tsx` when calling the new asynchronous function.