### PR TITLE
Fix: Correct import/export errors in frontend

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
     <meta property="twitter:description" content="Sample E-Commerce Web Application" />
     <meta property="twitter:image" content="/images/home-open-graph.png">
     <meta property="twitter:card" content="/images/home-open-graph.png">
-    <script type="module" crossorigin src="/assets/index-1b60u6Dr.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-dibw378O.css">
+    <script type="module" crossorigin src="/assets/index-U4G7gutH.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-lwCrOfkG.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/pages/ProfilePage/DataCards.tsx
+++ b/frontend/src/pages/ProfilePage/DataCards.tsx
@@ -1,9 +1,9 @@
 import { HeartIcon, ShoppingBagIcon } from '@heroicons/react/24/outline';
 import DataCard from './DataCard';
-import { getOrderCount } from '@/service/order';
+import { useOrderCount } from './useOrderCount';
 
 export default function DataCards() {
-  const userOrderCount = getOrderCount();
+  const userOrderCount = useOrderCount();
   return (
     <div className="w-full grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-8 mt-8">
       <DataCard label="Order Count" value={userOrderCount} Icon={ShoppingBagIcon} />

--- a/frontend/src/pages/ProfilePage/LogoutBtn.tsx
+++ b/frontend/src/pages/ProfilePage/LogoutBtn.tsx
@@ -3,7 +3,6 @@ import { googleLogout } from '@react-oauth/google';
 import { ArrowRightStartOnRectangleIcon } from '@heroicons/react/24/outline';
 import { useAuth } from '@/hooks/useAuth';
 import { useUserAddress } from '@/hooks/useUserAddress';
-import { removeAllOrders } from '@/service/order';
 import ConfirmDialog from '@/components/shared/dialog/ConfirmDialog';
 
 export default function LogoutBtn() {
@@ -26,7 +25,6 @@ export default function LogoutBtn() {
     // Clear LocalStorage Data
     logoutFromApp();
     removeAddress();
-    removeAllOrders();
   };
 
   return (

--- a/frontend/src/pages/ProfilePage/useOrderCount.ts
+++ b/frontend/src/pages/ProfilePage/useOrderCount.ts
@@ -1,0 +1,17 @@
+import { getOrderList } from '@/service/order';
+import { useEffect, useState } from 'react';
+
+export function useOrderCount() {
+  const [orderCount, setOrderCount] = useState(0);
+
+  useEffect(() => {
+    async function fetchOrderCount() {
+      const orders = await getOrderList();
+      setOrderCount(orders.length);
+    }
+
+    fetchOrderCount();
+  }, []);
+
+  return orderCount;
+}


### PR DESCRIPTION
This commit addresses two import/export errors in the frontend application.

1.  In `DataCards.tsx`, the component was trying to import and use `getOrderCount` which was not exported from `service/order.ts`. This has been fixed by creating a new custom hook `useOrderCount` that asynchronously fetches the order count.

2.  In `LogoutBtn.tsx`, the component was trying to import `removeAllOrders` which was also not exported from `service/order.ts`. This has been fixed by removing the import and the corresponding function call.