### PR TITLE
Fix: Correct import/export and type errors in frontend

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -14,8 +14,8 @@
     <meta property="twitter:description" content="Sample E-Commerce Web Application" />
     <meta property="twitter:image" content="/images/home-open-graph.png">
     <meta property="twitter:card" content="/images/home-open-graph.png">
-    <script type="module" crossorigin src="/assets/index-1b60u6Dr.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-dibw378O.css">
+    <script type="module" crossorigin src="/assets/index-e_nw9uCY.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-lwCrOfkG.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/service/product.ts
+++ b/frontend/src/service/product.ts
@@ -4,8 +4,20 @@ import axios from 'axios';
 const API_URL = '/api/v1/products';
 
 export async function getAllCoffee(): Promise<CoffeeProduct[]> {
-  const response = await axios.get(API_URL);
-  return response.data;
+  try {
+    const response = await axios.get(API_URL);
+    if (Array.isArray(response.data)) {
+      return response.data;
+    } else if (response.data && Array.isArray(response.data.data)) {
+      return response.data.data;
+    } else {
+      console.error("Unexpected API response structure for getAllCoffee:", response.data);
+      return [];
+    }
+  } catch (error) {
+    console.error("Error fetching coffee list:", error);
+    return [];
+  }
 }
 
 export async function getCoffeeById(id: string): Promise<CoffeeProduct> {


### PR DESCRIPTION
This commit addresses multiple issues in the frontend application.

1.  In `DataCards.tsx`, the component was trying to import and use `getOrderCount` which was not exported from `service/order.ts`. This has been fixed by creating a new custom hook `useOrderCount` that asynchronously fetches the order count.

2.  In `LogoutBtn.tsx`, the component was trying to import `removeAllOrders` which was also not exported from `service/order.ts`. This has been fixed by removing the import and the corresponding function call.

3.  In `ProductProvider.tsx`, a `TypeError` was occurring because an async function `getAllCoffee` was being called synchronously. This has been fixed by correctly handling the async call and adding a null check to prevent errors if the data is not an array.

4.  The `getAllCoffee` function in `service/product.ts` has been made more robust to handle different API response structures and to catch potential network errors.