### PR TITLE
Fix: Add @Transactional to ProductService

### DIFF
--- a/backend/backend.log
+++ b/backend/backend.log
@@ -1,0 +1,1 @@
+Error: Unable to access jarfile backend/target/brewtopia-0.0.1-SNAPSHOT.jar

--- a/backend/src/main/java/com/coffeeshop/cms/service/ProductService.java
+++ b/backend/src/main/java/com/coffeeshop/cms/service/ProductService.java
@@ -6,6 +6,7 @@ import com.coffeeshop.cms.model.Product;
 import com.coffeeshop.cms.repository.ProductRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,12 +17,14 @@ public class ProductService {
     @Autowired
     private ProductRepository productRepository;
 
+    @Transactional(readOnly = true)
     public List<ProductDto> getAllProducts() {
         return productRepository.findAll().stream()
                 .map(this::convertToDto)
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public ProductDto getProductById(Long id) {
         return productRepository.findById(id)
                 .map(this::convertToDto)


### PR DESCRIPTION
The application was throwing a LazyInitializationException when fetching products because the variants were being loaded lazily outside of a transactional context. This change adds the @Transactional(readOnly = true) annotation to the getAllProducts and getProductById methods in the ProductService to ensure that the session remains open while the variants are being fetched.