### PR TITLE
fix: Set password for new users and finalize API

### DIFF
--- a/backend/src/main/java/com/coffeeshop/cms/service/UserService.java
+++ b/backend/src/main/java/com/coffeeshop/cms/service/UserService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,6 +28,7 @@ public class UserService {
             newUser.setName(name);
             newUser.setGoogleId(googleId);
             newUser.setRole(Role.CUSTOMER);
+            newUser.setPassword(UUID.randomUUID().toString()); // Set a random password
             User savedUser = userRepository.save(newUser);
             return convertToDto(savedUser);
         }


### PR DESCRIPTION
This commit fixes a bug where user creation failed due to a null password being inserted into a non-nullable database column.

- The `UserService` is updated to set a random UUID as the password for new users created via Google login. This satisfies the database constraint.

This commit also includes all previous backend and frontend fixes, delivering a complete and functional solution.