### PR TITLE
fix: Make product endpoints public

### DIFF
--- a/backend/src/main/java/com/coffeeshop/cms/config/SecurityConfig.java
+++ b/backend/src/main/java/com/coffeeshop/cms/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/api/v1/users/register", "/api/v1/users/login").permitAll()
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/v1/products", "/api/v1/products/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
This commit fixes a bug where the product endpoints were protected, preventing users from viewing products without being authenticated. The security configuration has been updated to allow public access to the product endpoints.