### PR TITLE
fix: Bypass Vite proxy for diagnostics

### DIFF
--- a/frontend/src/service/api.ts
+++ b/frontend/src/service/api.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 const tokenKeyName = 'coffee-shop-auth-token';
 
 const api = axios.create({
-  baseURL: '/api/v1',
+  baseURL: 'http://localhost:8080/api/v1',
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
This commit updates the frontend to send requests directly to the backend to help diagnose a 403 Forbidden error on registration. The baseURL in api.ts has been changed to the full backend URL.